### PR TITLE
Prevent vehicles from executing or being lassoed

### DIFF
--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -97,6 +97,9 @@
   <AM.Error.Grapple.InAnimation>{Target} cannot be lassoed right now</AM.Error.Grapple.InAnimation>
   <AM.Error.Grapple.SelfInAnimation>{Grappler} cannot lasso right now</AM.Error.Grapple.SelfInAnimation>
 
+  <AM.Error.Grapple.BadRace>{Target} is not a valid lasso target.</AM.Error.Grapple.BadRace>
+  <AM.Error.Grapple.BadRace.Short>{Target} is not a valid lasso target</AM.Error.Grapple.BadRace.Short>
+
   <AM.Error.Grapple.Mass>{Target} is too heavy for {Grappler} to lasso</AM.Error.Grapple.Mass>
   <AM.Error.Grapple.Mass.Short>{Target} is too heavy</AM.Error.Grapple.Mass.Short>
 

--- a/Source/1.6/AnimationMod/Controller/ActionController.cs
+++ b/Source/1.6/AnimationMod/Controller/ActionController.cs
@@ -15,6 +15,7 @@ namespace AM.Controller;
 
 public class ActionController
 {
+    public static readonly List<Predicate<Pawn>> CanExecutePredicates = [];
     public static readonly List<Predicate<Pawn>> CanBeExecutedPredicates = [];
 
     public static Func<IntVec3, Map, bool> LOSValidator => CheckCell;
@@ -211,6 +212,15 @@ public class ActionController
         if (req.Target == null && (req.Targets == null || !req.Targets.Any()))
             yield break;
 
+        foreach (var predicate in CanExecutePredicates)
+        {
+            if (!predicate(req.Executioner))
+            {
+                yield return new ExecutionAttemptReport(req, "BadRace");
+                yield break;
+            }
+        }
+
         // Missing weapon, unless Fists of Fury is active.
         var weapon = req.Executioner.GetFirstMeleeWeapon();
         if (weapon == null)
@@ -328,7 +338,7 @@ public class ActionController
         // Invalid target pawn or pawn race (currently used for Vehicles).
         foreach (var predicate in CanBeExecutedPredicates)
         {
-            if (!predicate(req.Target))
+            if (!predicate(target))
             {
                 return new ExecutionAttemptReport(req, "BadRace");
             }

--- a/Source/1.6/AnimationMod/Controller/ActionController.cs
+++ b/Source/1.6/AnimationMod/Controller/ActionController.cs
@@ -17,6 +17,7 @@ public class ActionController
 {
     public static readonly List<Predicate<Pawn>> CanExecutePredicates = [];
     public static readonly List<Predicate<Pawn>> CanBeExecutedPredicates = [];
+    public static readonly List<Predicate<Pawn>> CanBeGrappledPredicates = [];
 
     public static Func<IntVec3, Map, bool> LOSValidator => CheckCell;
 
@@ -124,6 +125,12 @@ public class ActionController
                 UpdateClosestCells(req, map) :
                 UpdateClosestCells(req, req.OccupiedMask.Value);
             return sc == 0 ? new GrappleAttemptReport(req, "NoDest") : GrappleAttemptReport.Success(default);
+        }
+
+        foreach (var predicate in CanBeGrappledPredicates)
+        {
+            if (!predicate(req.Target))
+                return new GrappleAttemptReport(req, "BadRace");
         }
 
         // Grappler is not target.

--- a/Source/1.6/VehiclesPatch/PatchCore.cs
+++ b/Source/1.6/VehiclesPatch/PatchCore.cs
@@ -20,6 +20,8 @@ public class PatchCore : Mod
         // If the pawn is a vehicle, don't allow execution.
         ActionController.CanExecutePredicates.Add(NotVehiclePawn);
         ActionController.CanBeExecutedPredicates.Add(NotVehiclePawn);
+        // Grappling is also not allowed on vehicles.
+        ActionController.CanBeGrappledPredicates.Add(NotVehiclePawn);
     }
 
     public static bool NotVehiclePawn(Pawn pawn)

--- a/Source/1.6/VehiclesPatch/PatchCore.cs
+++ b/Source/1.6/VehiclesPatch/PatchCore.cs
@@ -17,12 +17,13 @@ public class PatchCore : Mod
     public PatchCore(ModContentPack content) : base(content)
     {
         Log("Loaded vehicle framework patch!");
-        ActionController.CanBeExecutedPredicates.Add(IsValidExecuteTarget);
+        // If the pawn is a vehicle, don't allow execution.
+        ActionController.CanExecutePredicates.Add(NotVehiclePawn);
+        ActionController.CanBeExecutedPredicates.Add(NotVehiclePawn);
     }
 
-    public static bool IsValidExecuteTarget(Pawn pawn)
+    public static bool NotVehiclePawn(Pawn pawn)
     {
-        // If the pawn is a vehicle, don't allow execution.
         return pawn is not VehiclePawn;
     }
 }


### PR DESCRIPTION
This PR extends the Vehicle Framework compatibility patch so `VehiclePawn` is rejected from additional Melee Animation action roles, fixing #157.

Changes:

- Adds an executioner-side predicate hook to `ActionController`.
- Adds a lasso-target predicate hook to `ActionController`.
- Registers Vehicle Framework’s `VehiclePawn` rejection against:
  - execution initiators
  - execution targets
  - lasso targets
- Adds an English error string for invalid lasso targets.

This prevents vehicles from starting executions and prevents pawns from lassoing vehicles, while preserving the existing behavior that vehicles cannot be execution targets.

Validation:

```text
dotnet build Source/1.6/AnimationMod/AnimationMod.csproj
dotnet build Source/1.6/VehiclesPatch/VehiclesPatch.csproj